### PR TITLE
Some Improvement on `>bot help` command and change function name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# environment variable
+.env
+.venv/
+
+# swap files from editors
+*.swp
+
+# python cached
+__pycache__/


### PR DESCRIPTION
Improvement

-------------------------
the `>bot help` command previously not working properly. this is because

```python
    elif message.content.startswith('>bot help'):
        parts = message.content.split()
        if len(parts) > 2:
            if parts[2] == 'writeup':
                await help_writeup_command(message.channel)
            else:
                await send_help_message(message.channel)
```
this command will only process `>bot help` command if it has 3 parts for example 
`>bot help` wont work
`>bot help t` will work

![image](https://github.com/user-attachments/assets/a6a6c91e-4fb3-4807-9eb2-28f77ceb1c9d)


for the command when DM the bot

```
    if isinstance(message.channel, discord.DMChannel) and message.author != bot.user:
        if await is_member_of_guild(message.author):
            if message.content.startswith('>ask ctf '):
                parts = message.content.split(' ')
                if len(parts) > 3:
                    await handle_anonymous_question(message, parts[2])
                else:
                    await message.channel.send("Usage: >ask ctf <channel_name> <question>")
            elif message.content.startswith('>ask '):
                await handle_anonymous_question(message)
            elif message.content.startswith('>bot help'):
                await send_help_message(message.channel)
        else:
            await message.channel.send("You must be a member of the server to use this command.")
```

this section dont have the newly created `>bot help writeup` command. so i fix it
-------------------------

The `help_writeup_command` change into `send_writeup_command` for better standard


------------------------

Improvement Screenshots

`>bot help`
![image](https://github.com/user-attachments/assets/bee11f34-85d1-42e1-876e-a417b22d487c)


